### PR TITLE
Aio2400 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ Currently you can:
 - retrieve system information (Device ID, Serial No., Battery Pack information, general settings, ...)
 - continously retrieve telemetry data and send it to a local MQTT broker
 - disconnect the hub from Zendure's cloud broker and connect it to a local one (offline mode)
-    - not yet tested for the AIO2400
 - reconnect the hub to Zendure's cloud broker
-    - not yet tested for the AIO2400
 
 ## Why disconnect your SF Hub from the cloud? <a name="why"></a>
 That is a good question. A few reasons:
@@ -109,7 +107,7 @@ You can completely disconnect the hub from the Zendure cloud and have it report 
 
 Disconnecting works by reinitializing the hubs network connection (WiFi) and telling the hub to connect to a different MQTT broker.
 (eventually you need to change the WiFi first to another network before joining the target network)
-
+Note: for the AIO2400 you will need to reset the network connection manually by pressing the connection button for ~3s before connecting the AIO to your local broker.  
 ```
 $ pip3 install -r requirements.txt
 $ export WIFI_PWD="your_wifi_password"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This is a little tool to connect to Zendure's Solarflow hub via bluetooth to ret
 1. [How to use](#howto)
 1. [Use Cases](#usecase)
 
+## Supported Devices <a name="what"></a>
+- Solarflow Hub
+    - Hub1200
+    - Hub2000
+- AIO2400
 
 ## Features <a name="features"></a>
 Currently you can:
@@ -17,7 +22,9 @@ Currently you can:
 - retrieve system information (Device ID, Serial No., Battery Pack information, general settings, ...)
 - continously retrieve telemetry data and send it to a local MQTT broker
 - disconnect the hub from Zendure's cloud broker and connect it to a local one (offline mode)
+    - not yet tested for the AIO2400
 - reconnect the hub to Zendure's cloud broker
+    - not yet tested for the AIO2400
 
 ## Why disconnect your SF Hub from the cloud? <a name="why"></a>
 That is a good question. A few reasons:
@@ -107,7 +114,7 @@ Disconnecting works by reinitializing the hubs network connection (WiFi) and tel
 $ pip3 install -r requirements.txt
 $ export WIFI_PWD="your_wifi_password"
 $ export SF_DEVICE_ID="your_sf_deviceid"
-# your_sf_productid is 73bkTV for Hub1200 or A8yh63 for Hub2000
+# your_sf_productid is 73bkTV for Hub1200 or A8yh63 for Hub2000 and Ue4zY5 for AIO2400.
 $ export SF_PRODUCT_ID="your_sf_productid"
 $ python3 solarflow-bt-manager.py -d -w <WiFi SSID> -b <local MQTT broker>
 ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Disconnecting works by reinitializing the hubs network connection (WiFi) and tel
 $ pip3 install -r requirements.txt
 $ export WIFI_PWD="your_wifi_password"
 $ export SF_DEVICE_ID="your_sf_deviceid"
-# your_sf_productid is 73bkTV for Hub1200 or A8yh63 for Hub2000 and Ue4zY5 for AIO2400.
+# your_sf_productid is 73bkTV for Hub1200 or A8yh63 for Hub2000 and yWF7hV for AIO2400.
 $ export SF_PRODUCT_ID="your_sf_productid"
 $ python3 solarflow-bt-manager.py -d -w <WiFi SSID> -b <local MQTT broker>
 ```

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 bleak
-paho-mqtt==1.6.1
+paho-mqtt>=2.0.0

--- a/src/solarflow-bt-manager.py
+++ b/src/solarflow-bt-manager.py
@@ -37,7 +37,7 @@ def on_connect(client, userdata, flags, rc):
         log.error("Failed to connect, return code %d\n", rc)
 
 def local_mqtt_connect(broker, port):
-    client = mqtt_client.Client(client_id="solarflow-bt")
+    client = mqtt_client.Client(mqtt_client.CallbackAPIVersion.VERSION1, client_id="solarflow-bt")
     if mqtt_user is not None and mqtt_pwd is not None:
         client.username_pw_set(mqtt_user, mqtt_pwd)
     client.connect(broker,port)

--- a/src/solarflow-bt-manager.py
+++ b/src/solarflow-bt-manager.py
@@ -132,8 +132,12 @@ async def run(broker=None, port=None, info_only: bool = False, connect: bool = F
 
     if SF_PRODUCT_ID == '73bkTV':
       product_class = "zenp"
-    else:
+    elif SF_PRODUCT_ID == 'A8yh63': 
       product_class = "zenh"
+    elif SF_PRODUCT_ID == 'Ue4zY5':
+      product_class = "zenr"
+    else:
+      product_class = "zen"
 
     log.info("scan for: " + str(product_class))
 
@@ -236,7 +240,7 @@ def main(argv):
             print("Please provide your device ID via environment variable SF_DEVICE_ID")
             sys.exit()
         if SF_PRODUCT_ID is None:
-            print("Please provide your product ID via environment variable SF_PRODUCT_ID (73bkTV for Hub1200, A8yh63 for Hub2000")
+            print("Please provide your product ID via environment variable SF_PRODUCT_ID (73bkTV for Hub1200, A8yh63 for Hub2000, Ue4zY5 for AIO2400")
             sys.exit()
         print("Disconnecting Solarflow Hub from Zendure Cloud")
 

--- a/src/solarflow-bt-manager.py
+++ b/src/solarflow-bt-manager.py
@@ -135,7 +135,7 @@ async def run(broker=None, port=None, info_only: bool = False, connect: bool = F
       product_class = "zenp"
     elif SF_PRODUCT_ID == 'A8yh63': 
       product_class = "zenh"
-    elif SF_PRODUCT_ID == 'Ue4zY5':
+    elif SF_PRODUCT_ID == 'yWF7hV':
       product_class = "zenr"
     else:
       product_class = "zen"
@@ -241,7 +241,7 @@ def main(argv):
             print("Please provide your device ID via environment variable SF_DEVICE_ID")
             sys.exit()
         if SF_PRODUCT_ID is None:
-            print("Please provide your product ID via environment variable SF_PRODUCT_ID (73bkTV for Hub1200, A8yh63 for Hub2000, Ue4zY5 for AIO2400")
+            print("Please provide your product ID via environment variable SF_PRODUCT_ID (73bkTV for Hub1200, A8yh63 for Hub2000, yWF7hV for AIO2400")
             sys.exit()
         print("Disconnecting Solarflow Hub from Zendure Cloud")
 

--- a/src/solarflow-bt-manager.py
+++ b/src/solarflow-bt-manager.py
@@ -25,6 +25,7 @@ WIFI_PWD = os.environ.get('WIFI_PWD',None)
 WIFI_SSID = os.environ.get('WIFI_SSID',None)
 SF_DEVICE_ID = os.environ.get('SF_DEVICE_ID',None)
 SF_PRODUCT_ID = os.environ.get('SF_PRODUCT_ID','73bkTV')
+GLOBAL_INFO_POLLING_INTERVAL = os.environ.get('GLOBAL_INFO_POLLING_INTERVAL', 60)
 mqtt_user = os.environ.get('MQTT_USER',None)
 mqtt_pwd = os.environ.get('MQTT_PWD',None)
 mq_client: mqtt_client = None
@@ -179,11 +180,11 @@ async def run(broker=None, port=None, info_only: bool = False, connect: bool = F
                 getinfo = True
                 while True:
                     await bt_client.start_notify(SF_NOTIFY_CHAR,handle_rx)
-                    # fetch global info every minute
+                    # fetch global info every GLOBAL_INFO_POLLING_INTERVAL seconds
                     if getinfo:
                         await getInfo(bt_client)
                         getinfo = False
-                    getinfo = await asyncio.sleep(60, True)
+                    getinfo = await asyncio.sleep(int(GLOBAL_INFO_POLLING_INTERVAL), True)
     else:
         log.info("No Solarflow device found! You can try these steps:\n \
                   - Move closer to the hub\n \

--- a/src/solarflow-bt-manager.py
+++ b/src/solarflow-bt-manager.py
@@ -160,7 +160,7 @@ async def run(broker=None, port=None, info_only: bool = False, connect: bool = F
 
             if disconnect and broker and port and ssid and SF_DEVICE_ID:
                 await set_IoT_Url(bt_client,broker,port,ssid,SF_DEVICE_ID)
-                log.info("Setting IoTURL connection parameters - disconneect")
+                log.info("Setting IoTURL connection parameters - disconnect")
                 await asyncio.sleep(30)
                 return
 

--- a/src/solarflow-topic-mapper.py
+++ b/src/solarflow-topic-mapper.py
@@ -68,7 +68,7 @@ def on_connect(client, userdata, flags, rc):
 
 def connect_mqtt() -> mqtt_client:
     id = ''.join(random.choices(string.ascii_lowercase, k=5))
-    client = mqtt_client.Client(f'zen-topic-remap-{id}')
+    client = mqtt_client.Client(mqtt_client.CallbackAPIVersion.VERSION1,f'zen-topic-remap-{id}')
     if mqtt_user is not None and mqtt_pwd is not None:
         client.username_pw_set(mqtt_user, mqtt_pwd)
     client.on_connect = on_connect

--- a/src/solarflow-topic-mapper.py
+++ b/src/solarflow-topic-mapper.py
@@ -63,6 +63,7 @@ def on_message(client, userdata, msg):
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
         log.info("Connected to MQTT Broker!")
+        subscribe(client)
     else:
         log.error("Failed to connect, return code %d\n", rc)
 
@@ -85,7 +86,6 @@ def run():
     global devices
     global sf_product_id
     client = connect_mqtt()
-    subscribe(client)
     client.loop_start()
 
     while True:


### PR DESCRIPTION
### Adds support for the [AIO2400](https://zendure.de/products/aio-2400)
* enables "proxy mode" and direct broker connection for the AIO.
* the Bluetooth communication turned out to be more stable, with a lower polling rate of the global information. It is now configurable via environment variable while retaining 60s as default.
* After some time using the Bluetooth "proxy mode" i switched to directly connecting the AIO2400 to my local broker. Works quite well so far. 

### Other 
* updated to newer paho-mqtt version (change can be dropped if not desired.)